### PR TITLE
VERSION: 2.1.0.1

### DIFF
--- a/Src/Apps/Desktop/ScalesDesktop/Platforms/Windows/Package.appxmanifest
+++ b/Src/Apps/Desktop/ScalesDesktop/Platforms/Windows/Package.appxmanifest
@@ -11,7 +11,7 @@
   xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
   IgnorableNamespaces="uap rescap uap3 uap6 iot uap4 uap2">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=Владимирский Стандарт" Version="2.0.2.6" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=Владимирский Стандарт" Version="2.1.0.1" />
 
   <mp:PhoneIdentity PhoneProductId="EC66F7DD-78BD-4919-99F7-6D5AD5A05E41" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/Src/Apps/Desktop/ScalesDesktop/Source/Shared/Refit/Clients/DesktopRefitClient.cs
+++ b/Src/Apps/Desktop/ScalesDesktop/Source/Shared/Refit/Clients/DesktopRefitClient.cs
@@ -14,6 +14,7 @@ internal class DesktopRefitClient : IRefitClient
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
             })
-            .AddHttpMessageHandler<HostNameMessageHandler>();
+            .AddHttpMessageHandler<HostNameMessageHandler>()
+            .AddHttpMessageHandler<AcceptLanguageHandler>();
     }
 }

--- a/Src/Apps/Desktop/ScalesDesktop/appsettings.DevelopVS.json
+++ b/Src/Apps/Desktop/ScalesDesktop/appsettings.DevelopVS.json
@@ -3,6 +3,6 @@
   "MockPrinter": false,
   "MockScales": false,
   "Api": {
-    "BaseUrl": "https://scales-api-dev.kolbasa-vs.local/api/desktop"
+    "BaseUrl": "https://scales-api-dev.kolbasa-vs.local/desktop"
   }
 }

--- a/Src/Apps/Desktop/ScalesDesktop/appsettings.ReleaseVS.json
+++ b/Src/Apps/Desktop/ScalesDesktop/appsettings.ReleaseVS.json
@@ -1,6 +1,6 @@
 {
   "FullScreenMode": true,
   "Api": {
-    "BaseUrl": "https://scales-api.kolbasa-vs.local/api/desktop"
+    "BaseUrl": "https://scales-api.kolbasa-vs.local/desktop"
   }
 }

--- a/Src/Apps/Desktop/Ws.Desktop.Api/Program.cs
+++ b/Src/Apps/Desktop/Ws.Desktop.Api/Program.cs
@@ -60,7 +60,7 @@ RequestLocalizationOptions localizationOptions = new()
 {
     SupportedCultures = supportedCultures,
     SupportedUICultures = supportedCultures,
-    DefaultRequestCulture = new(Cultures.En.Name)
+    DefaultRequestCulture = new(Cultures.Ru.Name)
 };
 
 WebApplication app = builder.Build();

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Boxes/Impl/BoxApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Boxes/Impl/BoxApiService.private.cs
@@ -16,6 +16,7 @@ internal partial class BoxApiService
         {
             DbContext.BulkInsertOrUpdate(boxes, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(BoxEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(BoxEntity.CreateDt)];
             });

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Brands/Impl/BrandApiService.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Brands/Impl/BrandApiService.cs
@@ -1,5 +1,6 @@
 using Ws.PalychExchange.Api.App.Features.Brands.Common;
 using Ws.PalychExchange.Api.App.Features.Brands.Dto;
+using Ws.PalychExchange.Api.App.Shared.Middlewares;
 
 namespace Ws.PalychExchange.Api.App.Features.Brands.Impl;
 

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Brands/Impl/BrandApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Brands/Impl/BrandApiService.private.cs
@@ -41,6 +41,7 @@ internal partial class BrandApiService
         {
             DbContext.BulkInsertOrUpdate(brands, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(BrandEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(BrandEntity.CreateDt)];
             });
@@ -49,7 +50,7 @@ internal partial class BrandApiService
 
             OutputDto.AddSuccess(brands.ConvertAll(i => i.Id));
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             transaction.Rollback();
             OutputDto.AddError(brands.ConvertAll(i => i.Id), "Не предвиденная ошибка");

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Bundles/Impl/BundleApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Bundles/Impl/BundleApiService.private.cs
@@ -16,6 +16,7 @@ internal partial class BundleApiService
         {
             DbContext.BulkInsertOrUpdate(bundles, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(BundleEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(BundleEntity.CreateDt)];
             });

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Characteristics/Impl/CharacteristicApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Characteristics/Impl/CharacteristicApiService.private.cs
@@ -107,7 +107,7 @@ internal partial class CharacteristicApiService
         using IDbContextTransaction transaction = DbContext.Database.BeginTransaction();
         try
         {
-            DbContext.BulkDelete(characteristicToDelete);
+            DbContext.BulkDelete(characteristicToDelete, config => config.UseTempDB = true);
             transaction.Commit();
             OutputDto.AddSuccess(deletedUid);
         }

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Characteristics/Impl/CharacteristicApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Characteristics/Impl/CharacteristicApiService.private.cs
@@ -79,6 +79,7 @@ internal partial class CharacteristicApiService
         {
             DbContext.BulkInsertOrUpdate(characteristics, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(CharacteristicEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(CharacteristicEntity.CreateDt)];
             });

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Clips/Impl/ClipApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Clips/Impl/ClipApiService.private.cs
@@ -16,6 +16,7 @@ internal partial class ClipApiService
         {
             DbContext.BulkInsertOrUpdate(clips, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(ClipEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(ClipEntity.CreateDt)];
             });

--- a/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Plus/Impl/PluApiService.private.cs
+++ b/Src/Apps/Exchange/Ws.PalychExchange.Api/App/Features/Plus/Impl/PluApiService.private.cs
@@ -51,6 +51,7 @@ internal sealed partial class PluApiService
         {
             DbContext.BulkInsertOrUpdate(plus, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(PluEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(PluEntity.CreateDt), nameof(PluEntity.TemplateId)];
             });
@@ -109,6 +110,7 @@ internal sealed partial class PluApiService
         {
             DbContext.BulkInsertOrUpdate(nestings, options =>
             {
+                options.UseTempDB = true;
                 options.UpdateByProperties = [nameof(NestingEntity.Id)];
                 options.PropertiesToExcludeOnUpdate = [nameof(NestingEntity.CreateDt)];
             });

--- a/Src/Apps/Other/Api.Gateway/appsettings.Development.json
+++ b/Src/Apps/Other/Api.Gateway/appsettings.Development.json
@@ -7,7 +7,7 @@
     },
     "Routes": [
       {
-        "UpstreamPathTemplate": "/api/desktop/{everything}",
+        "UpstreamPathTemplate": "/desktop/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {
@@ -18,7 +18,7 @@
         "DangerousAcceptAnyServerCertificateValidator": true
       },
       {
-        "UpstreamPathTemplate": "/api/exchange/{everything}",
+        "UpstreamPathTemplate": "/exchange/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {
@@ -29,7 +29,7 @@
         "DangerousAcceptAnyServerCertificateValidator": true
       },
       {
-        "UpstreamPathTemplate": "/api/device-control/{everything}",
+        "UpstreamPathTemplate": "/device-control/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {

--- a/Src/Apps/Other/Api.Gateway/appsettings.json
+++ b/Src/Apps/Other/Api.Gateway/appsettings.json
@@ -7,7 +7,7 @@
     },
     "Routes": [
       {
-        "UpstreamPathTemplate": "/api/desktop/{everything}",
+        "UpstreamPathTemplate": "/desktop/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {
@@ -18,7 +18,7 @@
         "DangerousAcceptAnyServerCertificateValidator": true
       },
       {
-        "UpstreamPathTemplate": "/api/exchange/{everything}",
+        "UpstreamPathTemplate": "/exchange/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {
@@ -29,7 +29,7 @@
         "DangerousAcceptAnyServerCertificateValidator": true
       },
       {
-        "UpstreamPathTemplate": "/api/device-control/{everything}",
+        "UpstreamPathTemplate": "/device-control/{everything}",
         "DownstreamPathTemplate": "/api/{everything}",
         "DownstreamHostAndPorts": [
           {

--- a/Src/Apps/Web/DeviceControl/Source/Features/BarcodeConfigurator/BarcodeConfigurator.razor
+++ b/Src/Apps/Web/DeviceControl/Source/Features/BarcodeConfigurator/BarcodeConfigurator.razor
@@ -26,7 +26,10 @@
   </div>
 </CascadingValue>
 
-<div class="flex w-full py-4 gap-2 justify-end items-center overflow-hidden flex-wrap gap-y-8">
+<div class="flex w-full py-4 gap-2 justify-between items-center overflow-hidden flex-wrap gap-y-8">
+  <Badge Type="@BadgeType.Outline">
+    @WsDataLocalizer["ColLength"]: @ExtendedBarcodeDictionary.Sum(x => x.Example.Count(char.IsDigit))
+  </Badge>
   <div class="gap-2 flex">
     <Button Variant="ButtonVariantType.Outline" OnClick="@ResetBarcode">
       <ArrowUturnLeftIcon class="size-[1.1rem] md:mr-2"/>

--- a/Src/Apps/Web/DeviceControl/appsettings.Development.json
+++ b/Src/Apps/Web/DeviceControl/appsettings.Development.json
@@ -13,6 +13,6 @@
     "Authority": "http://10.0.204.55:7561",
     "RequireHttpsMetadata": false
   },
-  "WebApi": "https://scales-api-dev.kolbasa-vs.local/api/device-control",
+  "WebApi": "https://scales-api-dev.kolbasa-vs.local/device-control",
   "LabelaryApi": "http://api.labelary.com"
 }

--- a/Src/Apps/Web/DeviceControl/appsettings.json
+++ b/Src/Apps/Web/DeviceControl/appsettings.json
@@ -13,7 +13,7 @@
     "Authority": "http://10.0.204.55:80",
     "RequireHttpsMetadata": false
   },
-  "WebApi": "https://scales-api.kolbasa-vs.local/api/device-control",
+  "WebApi": "https://scales-api.kolbasa-vs.local/device-control",
   "LabelaryApi": "http://api.labelary.com",
   "AllowedHosts": "*"
 }

--- a/Src/Apps/Web/Ws.DeviceControl.Api/App/Shared/Helpers/UserHelper.cs
+++ b/Src/Apps/Web/Ws.DeviceControl.Api/App/Shared/Helpers/UserHelper.cs
@@ -29,7 +29,14 @@ public sealed class UserHelper(
 
     public async Task CanUserWorkWithProductionSiteAsync(Guid productionSiteId)
     {
+        if (productionSiteId == DefaultConsts.GuidMax)
+        {
+            bool isDeveloper = await ValidatePolicyAsync(PolicyEnum.Developer);
+            if (isDeveloper) return;
+        }
+
         bool isSenior = await ValidatePolicyAsync(PolicyEnum.SeniorSupport);
+
         if (isSenior && productionSiteId != DefaultConsts.GuidMax) return;
 
         bool canWork =

--- a/Src/Apps/Web/Ws.DeviceControl.Api/Ws.DeviceControl.Api.csproj
+++ b/Src/Apps/Web/Ws.DeviceControl.Api/Ws.DeviceControl.Api.csproj
@@ -6,10 +6,10 @@
     </ItemGroup>
 
     <ItemGroup Label="Packages">
-        <PackageReference Include="Keycloak.AuthServices.Authentication" Version="2.5.3" />
-        <PackageReference Include="Keycloak.AuthServices.Authorization" Version="2.5.3" />
-        <PackageReference Include="Keycloak.AuthServices.Common" Version="2.5.3" />
-        <PackageReference Include="ProjectionTools" Version="1.0.17" />
+        <PackageReference Include="Keycloak.AuthServices.Authentication" VersionOverride="2.5.3" />
+        <PackageReference Include="Keycloak.AuthServices.Authorization" VersionOverride="2.5.3" />
+        <PackageReference Include="Keycloak.AuthServices.Common" VersionOverride="2.5.3" />
+        <PackageReference Include="ProjectionTools" VersionOverride="1.0.17" />
     </ItemGroup>
 
     <ItemGroup Label="Projects">
@@ -18,11 +18,11 @@
         <ProjectReference Include="..\..\..\Libs\Ws.Shared\Ws.Shared.csproj" PrivateAssets="All" />
         <ProjectReference Include="..\..\..\Infrastructure\Ws.Database.EntityFramework\Ws.Database.EntityFramework.csproj" PrivateAssets="All" />
     </ItemGroup>
-    
+
     <ItemGroup Label="For testing additional files">
         <Content Include="zHttp\.profiles\*" />
     </ItemGroup>
-    
+
     <ItemGroup>
       <EmbeddedResource Update="App\Shared\Localization\ApplicationResources.resx">
         <Generator>PublicResXFileCodeGenerator</Generator>
@@ -41,7 +41,7 @@
         <LastGenOutput>ApplicationResources.ru-RU.Designer.cs</LastGenOutput>
       </EmbeddedResource>
     </ItemGroup>
-    
+
     <ItemGroup>
       <Compile Update="App\Shared\Localization\ApplicationResources.Designer.cs">
         <DesignTime>True</DesignTime>

--- a/Src/Apps/Web/Ws.DeviceControl.Api/appsettings.json
+++ b/Src/Apps/Web/Ws.DeviceControl.Api/appsettings.json
@@ -5,5 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Keycloak": {
+    "realm": "blazor",
+    "auth-server-url": "http://10.0.204.55:80",
+    "ssl-required": "none",
+    "resource": "blazor-client",
+    "verify-token-audience": false,
+    "credentials": {
+      "secret": "8XOoLh9GSbMfyee97EHmnJ2udv3Vt3pw"
+    }
+  },
   "AllowedHosts": "*"
 }

--- a/Src/Apps/Web/Ws.DeviceControl.Models/Ws.DeviceControl.Models.csproj
+++ b/Src/Apps/Web/Ws.DeviceControl.Models/Ws.DeviceControl.Models.csproj
@@ -5,9 +5,9 @@
     </ItemGroup>
 
     <ItemGroup Label="Packages">
-      <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.8" />
-      <PackageReference Include="TscZebra.Plugin.Abstractions" Version="1.0.4" />
+      <PackageReference Include="Microsoft.AspNetCore.Authorization" VersionOverride="8.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" VersionOverride="8.0.8" />
+      <PackageReference Include="TscZebra.Plugin.Abstractions" VersionOverride="1.0.4" />
     </ItemGroup>
 
     <ItemGroup Label="Projects">

--- a/Src/Libs/Ws.Barcodes/Features/Barcodes/Utils/BarcodeVarUtils.cs
+++ b/Src/Libs/Ws.Barcodes/Features/Barcodes/Utils/BarcodeVarUtils.cs
@@ -62,8 +62,8 @@ public static partial class BarcodeVarUtils
             CreateVariable(() => barcodeBuilder.WeightNet, "{0:D5}"),
             CreateVariable(() => barcodeBuilder.BundleCount, "{0:D2}"),
             CreateVariable(() => barcodeBuilder.ExpirationDay, "{0:D3}"),
-            CreateVariable(() => barcodeBuilder.ProductDt, "{0:yyMMdd}"),
-            CreateVariable(() => barcodeBuilder.ExpirationDt, "{0:yyMMdd}")
+            CreateVariable(() => barcodeBuilder.ProductDt, "{0:yyMMdd}", true),
+            CreateVariable(() => barcodeBuilder.ExpirationDt, "{0:yyMMdd}", true)
         ];
     }
 

--- a/Src/Libs/Ws.Shared/Utils/ConfigurationUtil.cs
+++ b/Src/Libs/Ws.Shared/Utils/ConfigurationUtil.cs
@@ -13,7 +13,7 @@ public static class ConfigurationUtil
 
     public static ConfigurationType Config =>
 #if RELEASEVS
-        EnumConfiguration.ReleaseVs;
+        ConfigurationType.ReleaseVs;
 #else
         ConfigurationType.DevelopVs;
 #endif


### PR DESCRIPTION
### Core Changes
- Refact: move from client-database to client-server model
- Refact: update architecture (utils, helpers)
- Add: architecture tests
- Add: roslynator code analyzer
- Add: API for each frontend project
- Feat: centralize package management [#4844b7c](https://github.com/VladStandard/WeightService/commit/4844b7c25e4e2bb29b9931b285555db43370c3db)
- Feat: shared validators for both frontend and backend

### Database
- Update: fully migrate from NHibernate to Entity Framework
- Fix: ensure proper handling of UTC format [#21646cd](https://github.com/VladStandard/WeightService/commit/21646cd27bddad8bcdffacb2c1c6d720b2269d0f)

### 1C Exchange
- Fix: replace bulk insert extension package [f52a103](https://github.com/VladStandard/WeightService/commit/f52a10377cc28a561e55202d7513782b08266db2)

### API
- Feat: authorized requests (dns, keycloak) [#e15dbd3](https://github.com/VladStandard/WeightService/commit/e15dbd39c45f1ec93fbd1e2a6011bfc1bda7a133) [#b58c60c](https://github.com/VladStandard/WeightService/commit/b58c60c9acfbb7268a631883ee869c3dfeebef6e) 
- Feat: send lightweight DTO versions
- Feat: send localized server errors (accept language header) [#8e6c20f](https://github.com/VladStandard/WeightService/commit/8e6c20fd0ea3ba5596dd807bc25155678871c29c)

### UI Changes
- Fix: reduce font file sizes [#b5e5deb](https://github.com/VladStandard/WeightService/commit/b5e5debae7b2a51d2aa85500c0ec4ad442f18428)
- Add: combobox component [#d1c8162](https://github.com/VladStandard/WeightService/commit/d1c816202f7b3685878bc6b47bc6eec31de75a2f)
- Refact: select component [#cd9ab9c](https://github.com/VladStandard/WeightService/commit/cd9ab9c0b7ce58a2c5107d32602421d7729dafc2)

### Device Control
- Update: replace all SQL requests with API requests
- Add: fluxor (global state manager)
- Add: phetch (server state manager, caching, optimistic updates)
- Feat: serialize localized server errors
- Fix: disable pre-rendering (to resolve double initialization issue)
- Style: redesign sidebar [#14a91da](https://github.com/VladStandard/WeightService/commit/14a91dae0bcded2404a84b2d0afef6331939f71c)
- Fix: update UI after auth state changes [#f69d118](https://github.com/VladStandard/WeightService/commit/f69d11880f83ee4456ecd7a167812a8a6b2476cd)
- Feat: double confirmation for deletion actions [#afd4c02](https://github.com/VladStandard/WeightService/commit/afd4c0206c1f13824ad97daa4dbf15e50622817f)
- Feat: add CAPTCHA to the barcode configurator [#760179d](https://github.com/VladStandard/WeightService/commit/760179d4acca7678a078cd6625444f02f0731c91)
- Update: redesign and improve barcode configurator logic [#2e50526](https://github.com/VladStandard/WeightService/commit/2e50526da75bf3d7d6fe01e923f02e666fbb5213)
- Fix: correct role accessibility [#90d22dd](https://github.com/VladStandard/WeightService/commit/90d22dd10e3c4eab2d0be8bbb07907a06e3e2a6a)

### Scales Desktop
- Add: fluxor (global state manager) [#e474e88](https://github.com/VladStandard/WeightService/commit/e474e882765d3d9c2eb8fe3c42d8e2b297933860)
- Add: phetch (server state manager, caching, optimistic updates)
- Refact: replace iText7 with a native browser solution [#c8c6f93](https://github.com/VladStandard/WeightService/commit/c8c6f939c5e3d57919a0a198668056730546c1a4)
- Add: serialization for localized server errors
- Feat: mock device services [#c4c678f](https://github.com/VladStandard/WeightService/commit/c4c678f112ec7d0a76d21476413c7d340c0774a7)
- Fix: hide virtual keyboard in kneading dialog [#edcfa04](https://github.com/VladStandard/WeightService/commit/edcfa0479b0566f1aaf5cf9042880ab3d61cdf92)
- Update: complete prototype of pallet functional